### PR TITLE
bugfix: enable scroll when content overflown

### DIFF
--- a/components/modal-card/index.js
+++ b/components/modal-card/index.js
@@ -122,7 +122,7 @@ export default function ModalCard({ children }) {
                         </h3>
                       </div>
                       <div className="border-t border-gray-200 px-4 py-5 sm:p-0">
-                        <dl className="sm:divide-y sm:divide-gray-200">
+                        <dl className="sm:divide-y sm:divide-gray-200 overflow-auto">
                           <div className="py-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
                             <dt className="text-sm font-medium text-gray-500">
                               Current Owner


### PR DESCRIPTION
A small yet effective solution. Basically when the view frame shrinks from the threshold content, CSS overflow auto will automatically judge between visible and scroll .. 

Closes #29 