### PR TITLE
bugfix: fix ui issue of modal jumping at tablet size

### DIFF
--- a/components/modal-card/index.js
+++ b/components/modal-card/index.js
@@ -112,12 +112,12 @@ export default function ModalCard({ children }) {
       <div className="">
         {isComponentVisible && (
           <div
-            className="bg-gray-500 bg-opacity-75 fixed z-10 inset-0 overflow-y-auto"
+            className="bg-gray-500 bg-opacity-75 fixed z-10 inset-0"
             aria-labelledby="modal-title"
             role="dialog"
             aria-modal="true"
           >
-            <div className="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center md:block md:p-0">
               <span
                 className="hidden sm:inline-block sm:align-middle sm:h-screen"
                 aria-hidden="true"


### PR DESCRIPTION
The issue was due to the responsive class utilities being acted only over sm size, and a malfunctioned flex value. Fixed it and this is what the result looks like for 3 sizes.

Tablet: 
<img width="815" alt="Screenshot 2021-04-13 at 5 09 53 AM" src="https://user-images.githubusercontent.com/32637757/114475755-7de05700-9c16-11eb-8dbc-25ea04c57e4e.png">

Phone: 
<img width="644" alt="Screenshot 2021-04-13 at 5 10 12 AM" src="https://user-images.githubusercontent.com/32637757/114475777-889aec00-9c16-11eb-9c69-4b8e3b91fcfa.png">

Desktop: 
<img width="1251" alt="Screenshot 2021-04-13 at 5 10 27 AM" src="https://user-images.githubusercontent.com/32637757/114475792-90f32700-9c16-11eb-8358-2415ad273580.png">

Closes #31 