### PR TITLE
chore: hide transaction hash when overflown

### DIFF
--- a/components/modal-card/index.js
+++ b/components/modal-card/index.js
@@ -8,7 +8,7 @@ import Steps from '../steps';
 import Input from '../input';
 
 import InputContext from '../../contexts/inputs';
-import UserContext from '../../contexts/user';
+// import UserContext from '../../contexts/user';
 import PunkContext from '../../contexts/punk';
 import useComponentVisible from '../../hooks/useComponentVisible';
 import { short } from '../../utils/';
@@ -81,7 +81,7 @@ export default function ModalCard({ children }) {
   );
   const [punkProvenance, setPunkProvenance] = useState([]);
   // TODO
-  const { address } = useContext(UserContext);
+  // const { address } = useContext(UserContext);
   const { transaction } = useContext(InputContext);
 
   useEffect(() => {
@@ -212,7 +212,7 @@ export default function ModalCard({ children }) {
                     <div className="mb-4">
                       <Steps />
                     </div>
-                    <div className="mb-4 text-center">
+                    <div className="mb-4 text-center truncate md:w-50">
                       <>
                         {/* <span className="bg-white text-lg font-medium text-gray-900 no-wrap">
     </span> */}

--- a/contexts/punk.js
+++ b/contexts/punk.js
@@ -165,7 +165,7 @@ export function PunkProvider({ children }) {
       });
 
     // todo: for current address. so owner is the current address
-    request(ENDPOINT, queryCryptopunksOfOwner(currentAddress)).then(
+    request(ENDPOINT, provenanceOwnerQuery).then(
       ({ userAddresses }) => {
         const { cryptopunks } = userAddresses[0];
         const punks = [];
@@ -177,7 +177,6 @@ export function PunkProvider({ children }) {
             punks.push(new Cryptopunk(punk.id, currentAddress, '', '', ''));
           }
         });
-        console.log(punks);
         setOwnedPunks(punks);
       }
     );


### PR DESCRIPTION
Just a minor fix .. 

Sample screenshot.
<img width="647" alt="Screenshot 2021-04-13 at 11 55 54 PM" src="https://user-images.githubusercontent.com/32637757/114602037-cb5ed180-9cb3-11eb-8af2-a8b4b13cca09.png">

Closes #39 
