### PR TITLE
bugfix: hide hamburger behind modal to acheive complete overlay

### DIFF
--- a/components/header/index.js
+++ b/components/header/index.js
@@ -32,7 +32,7 @@ export default function Header({ activeTab }) {
 
   return (
     <>
-      <div className="relative bg-white">
+      <div style={{ zIndex: 1 }} className="relative bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6">
           <div className="flex justify-between items-center border-b-2 border-gray-100 py-6 md:justify-start md:space-x-10">
             <div className="flex justify-start lg:w-0 lg:flex-1">
@@ -190,10 +190,7 @@ export default function Header({ activeTab }) {
                                   {address && (
                                     <>
                                       <div>{short(address)}</div> &nbsp;{' '}
-                                      <img
-                                        className="m-auto"
-                                        src={icon}
-                                      />
+                                      <img className="m-auto" src={icon} />
                                     </>
                                   )}
                                 </div>


### PR DESCRIPTION
The problem with the current working is, the hamburger is peeking inside the modal irrespective of its state, it's fixed now by pushing the modal overlay forward, thereby accomplishing total modal effect .. Misclicks are now avoided .. 

Sample screenshot
<img width="679" alt="Screenshot 2021-04-14 at 12 24 30 AM" src="https://user-images.githubusercontent.com/32637757/114605521-cac83a00-9cb7-11eb-83c7-ece564b031bb.png">

Closes #37  .. 